### PR TITLE
Implement EDD-013 Phase 2: workspace lifecycle E2E test

### DIFF
--- a/e2e/tests/02-workspace-lifecycle.spec.ts
+++ b/e2e/tests/02-workspace-lifecycle.spec.ts
@@ -1,0 +1,78 @@
+import { type Browser, type BrowserContext, type Page, expect, test } from "@playwright/test";
+import { connectBrowser, createTestContext, isTestProfile } from "../helpers/platform";
+import { deleteWorkspaceViaApi, provisionTimeout, uniqueWorkspaceName } from "../helpers/workspace";
+
+test.describe("Workspace lifecycle: create → provision → stop → delete", () => {
+	test.describe.configure({ mode: "serial" });
+
+	let browser: Browser;
+	let context: BrowserContext;
+	let page: Page;
+	const workspaceName = uniqueWorkspaceName();
+
+	test.beforeAll(async () => {
+		browser = await connectBrowser();
+		context = await createTestContext(browser);
+		page = await context.newPage();
+	});
+
+	test.afterAll(async () => {
+		try {
+			await deleteWorkspaceViaApi(workspaceName);
+		} catch {
+			// Best-effort cleanup
+		}
+		await context?.close();
+		if (isTestProfile()) await browser?.close();
+	});
+
+	test("open create workspace dialog", async () => {
+		await page.goto("/app/workspaces");
+		await page.getByRole("button", { name: "New workspace" }).click();
+		await expect(page.getByRole("dialog")).toBeVisible();
+		await expect(page.getByRole("heading", { name: "Create workspace" })).toBeVisible();
+	});
+
+	test("fill in workspace name and submit", async () => {
+		await page.getByLabel("Name").fill(workspaceName);
+		await page.getByRole("button", { name: "Create workspace" }).click();
+	});
+
+	test("navigates to workspace detail page", async () => {
+		await expect(page).toHaveURL(/\/app\/workspaces\//);
+		await expect(page.getByRole("heading", { name: workspaceName })).toBeVisible();
+	});
+
+	test("workspace provisions and reaches running state", async () => {
+		await expect(page.getByText("Running")).toBeVisible({
+			timeout: provisionTimeout(),
+		});
+	});
+
+	test("Open IDE link appears when running", async () => {
+		await expect(page.getByRole("link", { name: "Open IDE" })).toBeVisible();
+	});
+
+	test("stop the workspace", async () => {
+		await page.getByRole("button", { name: "Stop" }).click();
+		await expect(page.getByRole("dialog")).toBeVisible();
+		await page.getByRole("button", { name: "Stop workspace" }).click();
+		await expect(page.getByText("Stopped")).toBeVisible({
+			timeout: isTestProfile() ? 10_000 : 60_000,
+		});
+	});
+
+	test("delete the workspace", async () => {
+		await page.getByRole("button", { name: "Delete" }).click();
+		await expect(page.getByRole("dialog")).toBeVisible();
+		await page.getByRole("button", { name: "Delete workspace" }).click();
+		await expect(page).toHaveURL(/\/app\/workspaces$/);
+	});
+
+	test("workspace no longer appears in the list", async () => {
+		const table = page.getByRole("table");
+		await expect(table.getByText(workspaceName)).not.toBeVisible({
+			timeout: 10_000,
+		});
+	});
+});

--- a/packages/worker/src/main.ts
+++ b/packages/worker/src/main.ts
@@ -28,7 +28,9 @@ const sshKeyPath = resolve(projectRoot, process.env.SSH_KEY_PATH ?? "images/ssh/
 const useStubVm = process.env.RUNTIME !== "tart";
 const runtime = useStubVm ? createStubRuntime() : createTartRuntime({ sshKeyPath });
 
-const workspaceService = createWorkspaceService({ db, queue, runtime, caddy, logger });
+const noopHealthCheck = async () => {};
+const healthCheck = useStubVm ? noopHealthCheck : undefined;
+const workspaceService = createWorkspaceService({ db, queue, runtime, caddy, logger, healthCheck });
 const processor = createProcessor({ workspaceService, logger });
 const pollLoop = createPollLoop({ queue, processor, logger });
 


### PR DESCRIPTION
## Summary
- Add full workspace lifecycle E2E test: create → provision → stop → delete through the UI
- Fix worker missing no-op health check for stub runtime (provisioning hung on fake VM IPs)
- Global-setup `ensureQueue()` ensures ElasticMQ workspace-jobs queue exists before tests run

## Test plan
- [x] All 8 lifecycle tests pass with test profile (`npm run test:e2e:lifecycle`) in ~16s
- [x] All 5 smoke tests still pass (`npm run test:e2e:smoke`)
- [ ] CI passes (may need merge conflict resolution with main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)