### PR TITLE
Add common utilities and fnm/Node.js to workspace image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run format:check
+      - run: shellcheck images/scripts/*.sh npm-scripts/*.sh
       # TODO: enable when source files exist
       # - run: npm run check
       # - run: npm run check:tsc

--- a/images/scripts/setup.sh
+++ b/images/scripts/setup.sh
@@ -47,6 +47,7 @@ $SUDO systemctl enable ssh
 $SUDO systemctl start ssh || true
 
 $SUDO -u "${CS_USER}" bash -c 'curl -fsSL https://fnm.vercel.app/install | bash'
+# shellcheck disable=SC2016
 $SUDO -u "${CS_USER}" bash -c 'export PATH="/home/admin/.local/share/fnm:$PATH" && eval "$(fnm env)" && fnm install --lts'
 
 $SUDO mkdir -p "/home/${CS_USER}/workspace"

--- a/npm-scripts/mvp-start-vm.sh
+++ b/npm-scripts/mvp-start-vm.sh
@@ -23,7 +23,7 @@ while getopts ":i:n:h" opt; do
 done
 
 tart clone "$IMAGE_NAME" "$VM_NAME"
-tart run "$VM_NAME" >/tmp/rockpool-${VM_NAME}.log 2>&1 &
+tart run "$VM_NAME" >"/tmp/rockpool-${VM_NAME}.log" 2>&1 &
 
 sleep 2
 


### PR DESCRIPTION
## Summary
- Expand workspace image apt packages: htop, tmux, vim, tree, less, file, man-db, strace, rsync, net-tools, dnsutils, iputils-ping, socat, build-essential, python3, unzip/zip
- Install fnm (Fast Node Manager) with Node.js LTS for per-user version management
- Verified on a fresh Tart VM: all tools present, Node 24.14.0 via fnm

## Test plan
- [x] `npm run mvp:build-image` succeeds
- [x] Fresh VM clone has all apt packages installed
- [x] `fnm --version` / `node --version` / `npm --version` work as admin user
- [x] Python 3, gcc, make available

🤖 Generated with [Claude Code](https://claude.com/claude-code)