### PR TITLE
feat: Add Firecracker runtime support for Linux (EDD-019)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # Tart VM storage
 .tart/
 
+# Firecracker VM storage
+.firecracker/
+
 # ElasticMQ JAR download
 .elasticmq/
 

--- a/development.env.example
+++ b/development.env.example
@@ -7,10 +7,12 @@
 # Environment
 NODE_ENV=development
 
-# Runtime
+# Runtime: "tart" (macOS), "firecracker" (Linux), "stub" (tests)
+# Auto-detected from platform if not set
 RUNTIME=tart
 SPA_PROXY_URL=http://localhost:5173
 SSH_KEY_PATH=images/ssh/rockpool_ed25519
+FIRECRACKER_BASE_PATH=.firecracker
 
 # GitHub OAuth — control plane (see doc/EDD/003_Caddy_Reverse_Proxy.md appendix)
 GITHUB_OAUTH_CLIENT_ID=

--- a/images/scripts/build-firecracker-rootfs.sh
+++ b/images/scripts/build-firecracker-rootfs.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOTFS_SIZE_MB=20480
+ROOTFS_PATH=".firecracker/base/rockpool-workspace.ext4"
+SETUP_SCRIPT="images/scripts/setup.sh"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+mkdir -p .firecracker/base
+
+# Create sparse file (doesn't actually allocate all space)
+dd if=/dev/zero of="$ROOTFS_PATH" bs=1M count=0 seek=$ROOTFS_SIZE_MB
+mkfs.ext4 -F "$ROOTFS_PATH"
+
+MOUNT_DIR=$(mktemp -d)
+sudo mount "$ROOTFS_PATH" "$MOUNT_DIR"
+
+# Install Debian minimal
+sudo debootstrap --include=systemd,systemd-sysv,dbus,iproute2,openssh-server,curl,jq,make \
+    bookworm "$MOUNT_DIR" http://deb.debian.org/debian
+
+# Create admin user
+sudo chroot "$MOUNT_DIR" useradd -m -s /bin/bash -G sudo admin
+sudo chroot "$MOUNT_DIR" sh -c 'echo "admin:admin" | chpasswd'
+
+# Copy and run the shared setup script
+sudo cp "$SETUP_SCRIPT" "$MOUNT_DIR/tmp/setup.sh"
+sudo chroot "$MOUNT_DIR" bash /tmp/setup.sh
+
+# Install Firecracker guest network setup
+sudo tee "$MOUNT_DIR/etc/systemd/system/rockpool-net.service" > /dev/null <<'EOF'
+[Unit]
+Description=Rockpool guest network setup
+Before=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/rockpool-net-setup.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo tee "$MOUNT_DIR/usr/local/bin/rockpool-net-setup.sh" > /dev/null <<'SCRIPT'
+#!/bin/bash
+# Read IP config from kernel command line
+# Format: rockpool.ip=172.16.0.2 rockpool.gw=172.16.0.1 rockpool.mask=30
+IP=$(cat /proc/cmdline | tr ' ' '\n' | grep rockpool.ip= | cut -d= -f2)
+GW=$(cat /proc/cmdline | tr ' ' '\n' | grep rockpool.gw= | cut -d= -f2)
+MASK=$(cat /proc/cmdline | tr ' ' '\n' | grep rockpool.mask= | cut -d= -f2)
+
+if [ -n "$IP" ] && [ -n "$GW" ] && [ -n "$MASK" ]; then
+    ip addr add "${IP}/${MASK}" dev eth0
+    ip link set dev eth0 up
+    ip route add default via "$GW"
+    echo "nameserver 1.1.1.1" > /etc/resolv.conf
+    echo "nameserver 8.8.8.8" >> /etc/resolv.conf
+fi
+SCRIPT
+
+sudo chmod +x "$MOUNT_DIR/usr/local/bin/rockpool-net-setup.sh"
+sudo chroot "$MOUNT_DIR" systemctl enable rockpool-net.service
+
+# Clean up
+sudo rm "$MOUNT_DIR/tmp/setup.sh"
+sudo umount "$MOUNT_DIR"
+rmdir "$MOUNT_DIR"
+
+echo "Rootfs built at $ROOTFS_PATH"

--- a/npm-scripts/firecracker-bridge-setup.sh
+++ b/npm-scripts/firecracker-bridge-setup.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BRIDGE="rockpool0"
+BRIDGE_IP="172.16.0.1/16"
+
+# Create bridge if it doesn't exist
+if ! ip link show "$BRIDGE" &>/dev/null; then
+    ip link add name "$BRIDGE" type bridge
+    ip addr add "$BRIDGE_IP" dev "$BRIDGE"
+    ip link set dev "$BRIDGE" up
+fi
+
+# Enable IP forwarding
+echo 1 > /proc/sys/net/ipv4/ip_forward
+
+# Determine outbound interface
+HOST_IFACE=$(ip -j route list default | jq -r '.[0].dev')
+
+# NAT for VM internet access
+iptables -t nat -C POSTROUTING -o "$HOST_IFACE" -s 172.16.0.0/16 -j MASQUERADE 2>/dev/null || \
+    iptables -t nat -A POSTROUTING -o "$HOST_IFACE" -s 172.16.0.0/16 -j MASQUERADE
+
+# Allow forwarding from bridge
+iptables -C FORWARD -i "$BRIDGE" -o "$HOST_IFACE" -j ACCEPT 2>/dev/null || \
+    iptables -A FORWARD -i "$BRIDGE" -o "$HOST_IFACE" -j ACCEPT
+iptables -C FORWARD -i "$HOST_IFACE" -o "$BRIDGE" -m state --state RELATED,ESTABLISHED -j ACCEPT 2>/dev/null || \
+    iptables -A FORWARD -i "$HOST_IFACE" -o "$BRIDGE" -m state --state RELATED,ESTABLISHED -j ACCEPT
+
+# Block inter-VM traffic (VMs should not talk to each other)
+iptables -C FORWARD -i "$BRIDGE" -o "$BRIDGE" -j DROP 2>/dev/null || \
+    iptables -A FORWARD -i "$BRIDGE" -o "$BRIDGE" -j DROP
+
+echo "Bridge $BRIDGE configured at $BRIDGE_IP with NAT via $HOST_IFACE"

--- a/npm-scripts/firecracker-net.sh
+++ b/npm-scripts/firecracker-net.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ACTION=$1
+TAP_NAME=$2
+TAP_IP=$3
+BRIDGE=$4
+
+case "$ACTION" in
+  create)
+    ip tuntap add dev "$TAP_NAME" mode tap
+    ip addr add "$TAP_IP" dev "$TAP_NAME"
+    ip link set dev "$TAP_NAME" up
+    ip link set dev "$TAP_NAME" master "$BRIDGE"
+    ;;
+  destroy)
+    ip link set dev "$TAP_NAME" down 2>/dev/null || true
+    ip link del "$TAP_NAME" 2>/dev/null || true
+    ;;
+esac

--- a/npm-scripts/firecracker-setup.sh
+++ b/npm-scripts/firecracker-setup.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARCH=$(uname -m)
+FC_VERSION="v1.10.1"
+KERNEL_URL="https://github.com/firecracker-microvm/firecracker/releases/download/${FC_VERSION}/firecracker-${FC_VERSION}-${ARCH}.tgz"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+FC_DIR="$PROJECT_ROOT/.firecracker"
+
+mkdir -p "$FC_DIR/kernel"
+mkdir -p "$FC_DIR/base"
+
+cd "$FC_DIR/kernel"
+
+if [ ! -f vmlinux ]; then
+    echo "Downloading Firecracker kernel..."
+    curl -fsSL "$KERNEL_URL" | tar xz --strip-components=1 "release-${FC_VERSION}-${ARCH}/vmlinux-*"
+    mv vmlinux-* vmlinux 2>/dev/null || true
+fi
+
+# Check for firecracker binary
+if ! command -v firecracker &> /dev/null; then
+    echo "Firecracker binary not found in PATH"
+    echo "Please install Firecracker or add it to your PATH"
+    echo "Download from: https://github.com/firecracker-microvm/firecracker/releases"
+    exit 1
+fi
+
+echo "Firecracker setup complete"
+echo "Kernel: $FC_DIR/kernel/vmlinux"
+echo "Binary: $(which firecracker)"

--- a/packages/runtime/src/firecracker-runtime.ts
+++ b/packages/runtime/src/firecracker-runtime.ts
@@ -1,0 +1,393 @@
+import { spawn } from "node:child_process";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { existsSync, mkdirSync, writeFileSync, readFileSync, rmSync, copyFileSync } from "node:fs";
+import { join, dirname, resolve } from "node:path";
+import type { RuntimeRepository, VmStatus } from "./types.ts";
+import { createSlotAllocator } from "./slot-allocator.ts";
+import { createSshCommands } from "./ssh-commands.ts";
+
+const execFileAsync = promisify(execFile);
+
+const DEFAULT_POLL_INTERVAL_MS = 1000;
+const DEFAULT_POLL_MAX_ATTEMPTS = 60;
+const STOP_TIMEOUT_MS = 10000;
+const BOOT_POLL_INTERVAL_MS = 500;
+const BOOT_POLL_MAX_ATTEMPTS = 30;
+
+type ExecFn = (bin: string, args: string[]) => Promise<string>;
+type SpawnFn = (bin: string, args: string[], cwd?: string) => void;
+
+function defaultExec(bin: string, args: string[]): Promise<string> {
+	return execFileAsync(bin, args).then(({ stdout }) => stdout.trim());
+}
+
+function defaultSpawn(bin: string, args: string[], _cwd?: string): void {
+	const child = spawn(bin, args, {
+		detached: true,
+		stdio: "ignore",
+	});
+	child.unref();
+}
+
+export interface FirecrackerRuntimeOptions {
+	basePath?: string;
+	kernelPath?: string;
+	baseImageDir?: string;
+	vmDir?: string;
+	bridgeName?: string;
+	subnetPrefix?: string;
+	vcpuCount?: number;
+	memSizeMib?: number;
+	sshKeyPath?: string;
+	sshUser?: string;
+	netScriptPath?: string;
+	exec?: ExecFn;
+	spawn?: SpawnFn;
+	pollIntervalMs?: number;
+	pollMaxAttempts?: number;
+}
+
+interface VmConfig {
+	bootSource: {
+		kernelImagePath: string;
+		bootArgs: string;
+	};
+	drives: Array<{
+		driveId: string;
+		isRootDevice: boolean;
+		isReadOnly: boolean;
+		pathOnHost: string;
+	}>;
+	machineConfig: {
+		vcpuCount: number;
+		memSizeMib: number;
+		smt: boolean;
+	};
+	networkInterfaces: Array<{
+		ifaceId: string;
+		guestMac: string;
+		hostDevName: string;
+	}>;
+}
+
+export function createFirecrackerRuntime(options: FirecrackerRuntimeOptions = {}): RuntimeRepository {
+	const exec = options.exec ?? defaultExec;
+	const spawnFn = options.spawn ?? defaultSpawn;
+	const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+	const pollMaxAttempts = options.pollMaxAttempts ?? DEFAULT_POLL_MAX_ATTEMPTS;
+
+	const projectRoot = new URL("../../..", import.meta.url).pathname;
+	const basePath = options.basePath ?? resolve(projectRoot, ".firecracker");
+	const kernelPath = options.kernelPath ?? join(basePath, "kernel", "vmlinux");
+	const baseImageDir = options.baseImageDir ?? join(basePath, "base");
+	const vmDir = options.vmDir ?? join(basePath, "vms");
+	const bridgeName = options.bridgeName ?? "rockpool0";
+	const subnetPrefix = options.subnetPrefix ?? "172.16";
+	const vcpuCount = options.vcpuCount ?? 2;
+	const memSizeMib = options.memSizeMib ?? 4096;
+	const sshKeyPath = options.sshKeyPath;
+	const sshUser = options.sshUser ?? "admin";
+	const netScriptPath = options.netScriptPath ?? join(projectRoot, "npm-scripts", "firecracker-net.sh");
+
+	// Ensure directories exist
+	mkdirSync(vmDir, { recursive: true });
+
+	const slotAllocator = createSlotAllocator({ basePath, subnetPrefix });
+	slotAllocator.load();
+
+	const getIpInternal = (name: string): string => {
+		const allocation = slotAllocator.get(name);
+		if (!allocation) {
+			throw new Error(`Firecracker: no IP allocation for VM "${name}"`);
+		}
+		return allocation.guestIp;
+	};
+
+	let sshCommands: ReturnType<typeof createSshCommands> | undefined;
+	if (sshKeyPath) {
+		sshCommands = createSshCommands({
+			sshKeyPath,
+			sshUser,
+			exec,
+			pollIntervalMs,
+			pollMaxAttempts,
+		});
+	}
+
+	async function runNetScript(action: "create" | "destroy", tapName: string, tapIp: string): Promise<void> {
+		await exec("sudo", [netScriptPath, action, tapName, `${tapIp}/30`, bridgeName]);
+	}
+
+	function writeVmConfig(name: string, allocation: ReturnType<typeof slotAllocator.get>): void {
+		if (!allocation) {
+			throw new Error(`Firecracker: no allocation for VM "${name}"`);
+		}
+
+		const config: VmConfig = {
+			bootSource: {
+				kernelImagePath: kernelPath,
+				bootArgs: [
+					"console=ttyS0",
+					"reboot=k",
+					"panic=1",
+					"pci=off",
+					`rockpool.ip=${allocation.guestIp}`,
+					`rockpool.gw=${allocation.tapIp}`,
+					`rockpool.mask=${allocation.mask}`,
+				].join(" "),
+			},
+			drives: [
+				{
+					driveId: "rootfs",
+					isRootDevice: true,
+					isReadOnly: false,
+					pathOnHost: join(vmDir, name, "rootfs.ext4"),
+				},
+			],
+			machineConfig: {
+				vcpuCount,
+				memSizeMib,
+				smt: false,
+			},
+			networkInterfaces: [
+				{
+					ifaceId: "eth0",
+					guestMac: allocation.guestMac,
+					hostDevName: allocation.tapName,
+				},
+			],
+		};
+
+		const configPath = join(vmDir, name, "vm.json");
+		mkdirSync(dirname(configPath), { recursive: true });
+		writeFileSync(configPath, JSON.stringify(config, null, 2));
+	}
+
+	async function waitForBoot(name: string): Promise<void> {
+		const vmPath = join(vmDir, name);
+		const socketPath = join(vmPath, "firecracker.sock");
+
+		for (let attempt = 0; attempt < BOOT_POLL_MAX_ATTEMPTS; attempt++) {
+			if (!existsSync(socketPath)) {
+				await new Promise((resolve) => setTimeout(resolve, BOOT_POLL_INTERVAL_MS));
+				continue;
+			}
+
+			// Socket exists, try to query the API
+			try {
+				await exec("curl", [
+					"--unix-socket",
+					socketPath,
+					"-X",
+					"GET",
+					"http://localhost/",
+				]);
+				return;
+			} catch {
+				// API not ready yet
+			}
+
+			await new Promise((resolve) => setTimeout(resolve, BOOT_POLL_INTERVAL_MS));
+		}
+		throw new Error(`Firecracker: timed out waiting for VM "${name}" to boot`);
+	}
+
+	async function sendCtrlAltDel(socketPath: string): Promise<void> {
+		await exec("curl", [
+			"--unix-socket",
+			socketPath,
+			"-X",
+			"PUT",
+			"--data",
+			'{"action_type": "SendCtrlAltDel"}',
+			"http://localhost/actions",
+		]);
+	}
+
+	async function isProcessRunning(pid: number): Promise<boolean> {
+		try {
+			process.kill(pid, 0);
+			return true;
+		} catch {
+			return false;
+		}
+	}
+
+	async function getPid(name: string): Promise<number | null> {
+		const pidPath = join(vmDir, name, "firecracker.pid");
+		if (!existsSync(pidPath)) {
+			return null;
+		}
+		const pid = Number.parseInt(readFileSync(pidPath, "utf-8").trim(), 10);
+		if (Number.isNaN(pid)) {
+			return null;
+		}
+		return pid;
+	}
+
+	return {
+		async create(name: string, image: string): Promise<void> {
+			// Allocate network slot
+			const allocation = slotAllocator.allocate(name);
+
+			// Create VM directory
+			const vmPath = join(vmDir, name);
+			mkdirSync(vmPath, { recursive: true });
+
+			// Copy base rootfs
+			const baseImage = join(baseImageDir, `${image}.ext4`);
+			if (!existsSync(baseImage)) {
+				throw new Error(`Firecracker: base image not found: ${baseImage}`);
+			}
+			copyFileSync(baseImage, join(vmPath, "rootfs.ext4"));
+
+			// Create TAP device
+			await runNetScript("create", allocation.tapName, allocation.tapIp);
+
+			// Write VM config
+			writeVmConfig(name, allocation);
+		},
+
+		async start(name: string): Promise<void> {
+			const vmPath = join(vmDir, name);
+			const socketPath = join(vmPath, "firecracker.sock");
+			const pidPath = join(vmPath, "firecracker.pid");
+			const configPath = join(vmPath, "vm.json");
+
+			// Clean up stale socket
+			if (existsSync(socketPath)) {
+				rmSync(socketPath);
+			}
+
+			// Spawn firecracker process
+			spawnFn("firecracker", ["--api-sock", socketPath, "--config-file", configPath], vmPath);
+
+			// Write PID
+			// We need to find the actual PID - this is a limitation since detached processes
+			// don't give us the PID easily. For now, we'll poll for the process.
+			// A better approach would be to use a wrapper script that writes the PID.
+			await new Promise((resolve) => setTimeout(resolve, 1000));
+
+			// Find firecracker process by socket
+			const pid = await exec("pgrep", ["-f", `firecracker.*${socketPath}`])
+				.then(({ stdout }) => Number.parseInt(stdout.trim().split("\n")[0], 10))
+				.catch(() => null);
+
+			if (pid) {
+				writeFileSync(pidPath, String(pid));
+			}
+
+			// Wait for VM to boot
+			await waitForBoot(name);
+		},
+
+		async stop(name: string): Promise<void> {
+			const vmPath = join(vmDir, name);
+			const socketPath = join(vmPath, "firecracker.sock");
+			const pidPath = join(vmPath, "firecracker.pid");
+
+			if (!existsSync(socketPath)) {
+				return;
+			}
+
+			// Send CtrlAltDel for graceful shutdown
+			try {
+				await sendCtrlAltDel(socketPath);
+			} catch {
+				// Ignore errors - VM might already be stopping
+			}
+
+			// Wait for process to exit
+			const startTime = Date.now();
+			while (Date.now() - startTime < STOP_TIMEOUT_MS) {
+				const pid = await getPid(name);
+				if (!pid || !(await isProcessRunning(pid))) {
+					break;
+				}
+				await new Promise((resolve) => setTimeout(resolve, 500));
+			}
+
+			// Force kill if still running
+			const pid = await getPid(name);
+			if (pid && await isProcessRunning(pid)) {
+				try {
+					process.kill(pid, "SIGKILL");
+				} catch {
+					// Ignore
+				}
+			}
+
+			// Clean up socket
+			if (existsSync(socketPath)) {
+				rmSync(socketPath);
+			}
+			if (existsSync(pidPath)) {
+				rmSync(pidPath);
+			}
+		},
+
+		async remove(name: string): Promise<void> {
+			const vmPath = join(vmDir, name);
+
+			// Stop if running
+			try {
+				await this.stop(name);
+			} catch {
+				// Ignore stop errors during remove
+			}
+
+			// Get allocation for cleanup
+			const allocation = slotAllocator.get(name);
+
+			// Destroy TAP device
+			if (allocation) {
+				try {
+					await runNetScript("destroy", allocation.tapName, allocation.tapIp);
+				} catch {
+					// Ignore TAP cleanup errors
+				}
+				slotAllocator.release(name);
+			}
+
+			// Remove VM directory
+			if (existsSync(vmPath)) {
+				rmSync(vmPath, { recursive: true });
+			}
+		},
+
+		async status(name: string): Promise<VmStatus> {
+			const vmPath = join(vmDir, name);
+
+			// Check if directory exists
+			if (!existsSync(vmPath)) {
+				return "not_found";
+			}
+
+			// Check if process is running
+			const pid = await getPid(name);
+			if (!pid) {
+				return "stopped";
+			}
+
+			const running = await isProcessRunning(pid);
+			return running ? "running" : "stopped";
+		},
+
+		getIp: getIpInternal,
+
+		async configure(name: string, env: Record<string, string>): Promise<void> {
+			if (!sshCommands) {
+				throw new Error("Firecracker: sshKeyPath is required for configure");
+			}
+			await sshCommands.configure(name, getIpInternal, env);
+		},
+
+		async clone(name: string, vmIp: string, repository: string, token?: string): Promise<void> {
+			if (!sshCommands) {
+				throw new Error("Firecracker: sshKeyPath is required for clone");
+			}
+			await sshCommands.clone(name, vmIp, repository, token);
+		},
+	};
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,3 +1,4 @@
 export { createStubRuntime } from "./stub-runtime.ts";
 export { createTartRuntime } from "./tart-runtime.ts";
+export { createFirecrackerRuntime } from "./firecracker-runtime.ts";
 export type { RuntimeRepository, VmStatus } from "./types.ts";

--- a/packages/runtime/src/slot-allocator.ts
+++ b/packages/runtime/src/slot-allocator.ts
@@ -1,0 +1,111 @@
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+export interface SlotAllocation {
+	slot: number;
+	tapName: string;
+	tapIp: string;
+	guestIp: string;
+	guestMac: string;
+	mask: number;
+}
+
+interface SlotState {
+	allocated: Record<string, number>;
+	nextSlot: number;
+}
+
+const SUBNET_PREFIX = "172.16";
+const TAP_IP_BASE = 1;
+const MASK = 30;
+
+export interface SlotAllocatorOptions {
+	basePath?: string;
+	subnetPrefix?: string;
+}
+
+export function createSlotAllocator(options: SlotAllocatorOptions = {}): {
+	allocate(name: string): SlotAllocation;
+	release(name: string): void;
+	get(name: string): SlotAllocation | undefined;
+	load(): void;
+	save(): void;
+} {
+	const basePath = options.basePath ?? ".firecracker";
+	const subnetPrefix = options.subnetPrefix ?? SUBNET_PREFIX;
+	const slotsFile = join(basePath, "slots.json");
+
+	let state: SlotState = {
+		allocated: {},
+		nextSlot: 0,
+	};
+
+	function computeAllocation(slot: number): SlotAllocation {
+		const slotOffset = slot * 4;
+
+		// TAP IP on host side: 172.16.X.Y where X = (slot*4) >> 8, Y = (slot*4) & 0xFF + 1
+		const tapIpOctet3 = (slotOffset >> 8) & 0xff;
+		const tapIpOctet4 = (slotOffset & 0xff) + TAP_IP_BASE;
+
+		// Guest IP: next address in the /30
+		const guestIpOctet3 = tapIpOctet3;
+		const guestIpOctet4 = tapIpOctet4 + 1;
+
+		// Guest MAC: 06:00:AC:10:XX:YY where XXYY is guest IP bytes
+		const macOctet5 = guestIpOctet3.toString(16).padStart(2, "0");
+		const macOctet6 = guestIpOctet4.toString(16).padStart(2, "0");
+
+		return {
+			slot,
+			tapName: `rp-tap${slot}`,
+			tapIp: `${subnetPrefix}.${tapIpOctet3}.${tapIpOctet4}`,
+			guestIp: `${subnetPrefix}.${guestIpOctet3}.${guestIpOctet4}`,
+			guestMac: `06:00:AC:10:${macOctet5}:${macOctet6}`,
+			mask: MASK,
+		};
+	}
+
+	return {
+		allocate(name: string): SlotAllocation {
+			const slot = state.nextSlot++;
+			state.allocated[name] = slot;
+			this.save();
+			return computeAllocation(slot);
+		},
+
+		release(name: string): void {
+			delete state.allocated[name];
+			this.save();
+		},
+
+		get(name: string): SlotAllocation | undefined {
+			const slot = state.allocated[name];
+			if (slot === undefined) {
+				return undefined;
+			}
+			return computeAllocation(slot);
+		},
+
+		load(): void {
+			if (!existsSync(slotsFile)) {
+				return;
+			}
+			try {
+				const content = readFileSync(slotsFile, "utf-8");
+				state = JSON.parse(content);
+			} catch {
+				// If file is corrupted, start fresh
+				state = { allocated: {}, nextSlot: 0 };
+			}
+		},
+
+		save(): void {
+			try {
+				mkdirSync(dirname(slotsFile), { recursive: true });
+				writeFileSync(slotsFile, JSON.stringify(state, null, 2));
+			} catch {
+				// Ignore save errors
+			}
+		},
+	};
+}

--- a/packages/runtime/src/ssh-commands.ts
+++ b/packages/runtime/src/ssh-commands.ts
@@ -1,0 +1,133 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+const DEFAULT_POLL_INTERVAL_MS = 1000;
+const DEFAULT_POLL_MAX_ATTEMPTS = 60;
+
+type ExecFn = (bin: string, args: string[]) => Promise<string>;
+
+function defaultExec(bin: string, args: string[]): Promise<string> {
+	return execFileAsync(bin, args).then(({ stdout }) => stdout.trim());
+}
+
+export interface SshCommandsOptions {
+	sshKeyPath: string;
+	sshUser?: string;
+	exec?: ExecFn;
+	pollIntervalMs?: number;
+	pollMaxAttempts?: number;
+}
+
+export function createSshCommands(options: SshCommandsOptions) {
+	const exec = options.exec ?? defaultExec;
+	const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+	const pollMaxAttempts = options.pollMaxAttempts ?? DEFAULT_POLL_MAX_ATTEMPTS;
+	const sshKeyPath = options.sshKeyPath;
+	const sshUser = options.sshUser ?? "admin";
+
+	async function sshExec(vmIp: string, cmd: string): Promise<string> {
+		const { stdout } = await execFileAsync("ssh", [
+			"-i",
+			sshKeyPath,
+			"-o",
+			"StrictHostKeyChecking=no",
+			"-o",
+			"UserKnownHostsFile=/dev/null",
+			"-o",
+			"ConnectTimeout=5",
+			`${sshUser}@${vmIp}`,
+			cmd,
+		]);
+		return stdout.trim();
+	}
+
+	async function waitForSsh(vmIp: string): Promise<void> {
+		for (let attempt = 0; attempt < pollMaxAttempts; attempt++) {
+			const ready = await sshExec(vmIp, "true")
+				.then(() => true)
+				.catch(() => false);
+			if (ready) return;
+			await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+		}
+		throw new Error(`SSH: timed out waiting for SSH on VM (${vmIp})`);
+	}
+
+	async function configure(
+		name: string,
+		getIp: (name: string) => Promise<string>,
+		env: Record<string, string>,
+	): Promise<void> {
+		const workspaceName = env.ROCKPOOL_WORKSPACE_NAME;
+		if (!workspaceName) return;
+
+		const vmIp = await getIp(name);
+		const folder = env.ROCKPOOL_FOLDER;
+
+		const yamlContent = [
+			"bind-addr: 0.0.0.0:8080",
+			"auth: none",
+			"cert: false",
+			`abs-proxy-base-path: /workspace/${workspaceName}`,
+		].join("\n");
+
+		const folderOverride = folder
+			? ` && sudo mkdir -p /etc/systemd/system/code-server@admin.service.d && printf '[Service]\\nExecStart=\\nExecStart=/usr/bin/code-server --bind-addr 0.0.0.0:8080 ${folder}\\n' | sudo tee /etc/system@admin.service.dd/system/code-server/folder.conf > /dev/null && sudo systemctl daemon-reload`
+			: "";
+
+		const cmd = `printf '%s\\n' '${yamlContent}' > /home/${sshUser}/.config/code-server/config.yaml${folderOverride} && sudo systemctl restart code-server@admin`;
+
+		await waitForSsh(vmIp);
+
+		for (let attempt = 0; attempt < pollMaxAttempts; attempt++) {
+			const ok = await sshExec(vmIp, cmd)
+				.then(() => true)
+				.catch(() => false);
+			if (ok) return;
+			await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+		}
+		throw new Error(`SSH: timed out configuring code-server on VM "${name}" (${vmIp})`);
+	}
+
+	async function clone(
+		_name: string,
+		vmIp: string,
+		repository: string,
+		token?: string,
+	): Promise<void> {
+		await waitForSsh(vmIp);
+
+		if (token) {
+			const helperScript = [
+				"#!/bin/sh",
+				'echo "protocol=https"',
+				'echo "host=github.com"',
+				'echo "username=x-access-token"',
+				`echo "password=${token}"`,
+			].join("\n");
+
+			await sshExec(
+				vmIp,
+				`mkdir -p /home/${sshUser}/.rockpool && printf '%s\\n' '${helperScript}' > /home/${sshUser}/.rockpool/git-credential-helper && chmod +x /home/${sshUser}/.rockpool/git-credential-helper`,
+			);
+			await sshExec(
+				vmIp,
+				`git config --global credential.helper '/home/${sshUser}/.rockpool/git-credential-helper'`,
+			);
+		}
+
+		const repoName = repository.split("/")[1];
+		await sshExec(
+			vmIp,
+			`git clone --depth 1 --single-branch https://github.com/${repository}.git /home/${sshUser}/${repoName}`,
+		);
+	}
+
+	return {
+		sshExec,
+		waitForSsh,
+		configure,
+		clone,
+	};
+}

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -17,6 +17,7 @@ export interface ServerConfig {
 	queueUrl: string;
 	platform: "darwin" | "linux";
 	sshKeyPath: string;
+	firecrackerBasePath: string;
 	auth: AuthConfig | null;
 	secureCookies: boolean;
 }
@@ -55,6 +56,7 @@ export function loadConfig(): ServerConfig {
 		queueUrl: process.env.QUEUE_URL ?? "http://localhost:9324/000000000000/workspace-jobs",
 		platform: (process.env.PLATFORM ?? process.platform) as "darwin" | "linux",
 		sshKeyPath: resolve(projectRoot, process.env.SSH_KEY_PATH ?? "images/ssh/rockpool_ed25519"),
+		firecrackerBasePath: resolve(projectRoot, process.env.FIRECRACKER_BASE_PATH ?? ".firecracker"),
 		auth,
 		secureCookies: process.env.SECURE_COOKIES === "true",
 	};


### PR DESCRIPTION
Implements Firecracker-based microVM runtime for Linux hosts:

- Add firecracker-runtime.ts implementing RuntimeRepository interface
- Add slot-allocator.ts for network IP/MAC allocation
- Add ssh-commands.ts shared SSH configure/clone methods
- Add networking scripts: bridge setup, TAP device management
- Add rootfs build script for Firecracker images
- Update server and worker to use platform-aware runtime selection
- Add FIRECRACKER_BASE_PATH config option

Runtime auto-detection:
- macOS: Uses Tart (default)
- Linux: Uses Firecracker (default)
- RUNTIME=stub forces stub runtime for testing
- RUNTIME=tart/firecracker overrides platform default
