### PR TITLE
Add preferences UI and E2E tests (EDD-020)

### DIFF
--- a/e2e/tests/06-preferences-save.spec.ts
+++ b/e2e/tests/06-preferences-save.spec.ts
@@ -1,0 +1,102 @@
+import { type Browser, type BrowserContext, expect, type Page, test } from "@playwright/test";
+import {
+	createTestContext,
+	createTestPage,
+	getApiUrl,
+	getAuthHeader,
+	launchBrowser,
+} from "../helpers/platform";
+import { deleteWorkspaceViaApi, pollUntilStatus, uniqueWorkspaceName } from "../helpers/workspace";
+
+const profile = process.env.E2E_PROFILE ?? "development";
+test.skip(profile === "ci", "Preferences save requires real VMs — skipped in CI profile");
+
+test.describe("Preferences: save from running workspace", () => {
+	test.describe.configure({ mode: "serial" });
+
+	let browser: Browser;
+	let context: BrowserContext;
+	let page: Page;
+	const workspaceName = uniqueWorkspaceName();
+	let workspaceId: string;
+
+	test.beforeAll(async () => {
+		browser = await launchBrowser();
+		context = await createTestContext(browser);
+		page = await createTestPage(context);
+
+		const apiUrl = getApiUrl();
+		const headers: Record<string, string> = {
+			"Content-Type": "application/json",
+			Authorization: getAuthHeader(),
+		};
+
+		const createRes = await fetch(`${apiUrl}/workspaces`, {
+			method: "POST",
+			headers,
+			body: JSON.stringify({
+				name: workspaceName,
+				image: "rockpool-workspace",
+			}),
+		});
+		const workspace = (await createRes.json()) as { id: string };
+		workspaceId = workspace.id;
+		await pollUntilStatus(workspaceId, "running");
+	});
+
+	test.afterAll(async () => {
+		try {
+			await deleteWorkspaceViaApi(workspaceName);
+		} catch {
+			// Best-effort cleanup
+		}
+		await page?.close();
+		await context?.close();
+		await browser?.close();
+	});
+
+	test("settings list API returns empty array initially", async () => {
+		const apiUrl = getApiUrl();
+		const headers: Record<string, string> = { Authorization: getAuthHeader() };
+
+		const res = await fetch(`${apiUrl}/settings`, { headers });
+		expect(res.ok).toBeTruthy();
+		const blobs = await res.json();
+		expect(Array.isArray(blobs)).toBeTruthy();
+	});
+
+	test("settings save API returns 404 for file not yet on disk", async () => {
+		const apiUrl = getApiUrl();
+		const headers: Record<string, string> = { Authorization: getAuthHeader() };
+
+		const res = await fetch(`${apiUrl}/settings/GitConfig?workspaceId=${workspaceId}`, {
+			method: "PUT",
+			headers,
+		});
+		expect(res.status).toBe(404);
+	});
+
+	test("workspace detail page shows preferences panel", async () => {
+		await page.goto(`/app/workspaces/${workspaceId}`);
+		await expect(page.getByRole("heading", { name: workspaceName })).toBeVisible();
+		await expect(page.getByText("Running")).toBeVisible({ timeout: 10_000 });
+
+		await expect(page.getByText("Preferences")).toBeVisible();
+		await expect(page.getByText("Editor Settings")).toBeVisible();
+		await expect(page.getByText("Keybindings")).toBeVisible();
+		await expect(page.getByText("Git Config")).toBeVisible();
+		await expect(page.getByRole("button", { name: "Save all" })).toBeVisible();
+	});
+
+	test("all preferences show Never before any save", async () => {
+		const rows = page.getByRole("row").filter({ hasText: "Never" });
+		await expect(rows).toHaveCount(3);
+	});
+
+	test("save all silently skips missing files", async () => {
+		await page.getByRole("button", { name: "Save all" }).click();
+
+		await expect(page.getByRole("button", { name: "Save all" })).toBeVisible({ timeout: 30_000 });
+		await expect(page.getByText(/failed to save/)).not.toBeVisible();
+	});
+});

--- a/packages/client/src/components/prefs-panel.tsx
+++ b/packages/client/src/components/prefs-panel.tsx
@@ -1,0 +1,142 @@
+import { Save } from "lucide-react";
+import { useState } from "react";
+import { useNotify } from "@/components/ui/banner";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import { useSaveSettings, useSettings } from "@/hooks/use-settings";
+import type { UserPrefsFileName } from "@/lib/api";
+import { timeAgo } from "@/lib/time";
+
+const PREF_LABELS: Record<UserPrefsFileName, string> = {
+	CodeServerSettings: "Editor Settings",
+	CodeServerKeybindings: "Keybindings",
+	GitConfig: "Git Config",
+};
+
+const ALL_PREFS: UserPrefsFileName[] = ["CodeServerSettings", "CodeServerKeybindings", "GitConfig"];
+
+interface PrefsPanelProps {
+	workspaceId: string;
+}
+
+export function PrefsPanel({ workspaceId }: PrefsPanelProps) {
+	const { data: settings, isPending } = useSettings();
+	const saveMutation = useSaveSettings();
+	const notify = useNotify();
+	const [savingAll, setSavingAll] = useState(false);
+
+	async function saveAll() {
+		setSavingAll(true);
+		const results = await Promise.allSettled(
+			ALL_PREFS.map((name) => saveMutation.mutateAsync({ name, workspaceId })),
+		);
+		let savedCount = 0;
+		for (const result of results) {
+			if (result.status === "fulfilled") savedCount++;
+		}
+		if (savedCount > 0) {
+			notify.success(`Saved ${savedCount} preference${savedCount > 1 ? "s" : ""}`);
+		}
+		setSavingAll(false);
+	}
+
+	const settingsMap = new Map(settings?.map((s) => [s.name, s]));
+
+	return (
+		<Card>
+			<CardHeader className="flex-row items-center justify-between space-y-0">
+				<CardTitle>Preferences</CardTitle>
+				<Button variant="outline" size="xs" disabled={savingAll} onClick={saveAll}>
+					<Save className="size-3" />
+					{savingAll ? "Saving..." : "Save all"}
+				</Button>
+			</CardHeader>
+			<CardContent>
+				{isPending && <PrefsSkeleton />}
+
+				{!isPending && (
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<TableHead>Setting</TableHead>
+								<TableHead>Last saved</TableHead>
+								<TableHead className="w-[80px]">Actions</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{ALL_PREFS.map((name) => {
+								const stored = settingsMap.get(name);
+								return (
+									<PrefRow
+										key={name}
+										name={name}
+										lastSaved={stored?.updatedAt}
+										workspaceId={workspaceId}
+									/>
+								);
+							})}
+						</TableBody>
+					</Table>
+				)}
+			</CardContent>
+		</Card>
+	);
+}
+
+function PrefRow({
+	name,
+	lastSaved,
+	workspaceId,
+}: {
+	name: UserPrefsFileName;
+	lastSaved?: string;
+	workspaceId: string;
+}) {
+	const saveMutation = useSaveSettings();
+	const notify = useNotify();
+
+	return (
+		<TableRow>
+			<TableCell className="text-sm">{PREF_LABELS[name]}</TableCell>
+			<TableCell className="text-sm text-muted-foreground">
+				{lastSaved ? timeAgo(lastSaved) : "Never"}
+			</TableCell>
+			<TableCell>
+				<Button
+					variant="ghost"
+					size="icon-xs"
+					disabled={saveMutation.isPending}
+					onClick={() =>
+						saveMutation.mutate(
+							{ name, workspaceId },
+							{
+								onSuccess: () => notify.success(`Saved ${PREF_LABELS[name]}`),
+							},
+						)
+					}
+				>
+					<Save className="size-3" />
+				</Button>
+			</TableCell>
+		</TableRow>
+	);
+}
+
+function PrefsSkeleton() {
+	return (
+		<div className="space-y-2">
+			<Skeleton className="h-8 w-full" />
+			<Skeleton className="h-8 w-full" />
+			<Skeleton className="h-8 w-full" />
+		</div>
+	);
+}

--- a/packages/client/src/hooks/use-settings.ts
+++ b/packages/client/src/hooks/use-settings.ts
@@ -1,0 +1,23 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { UserPrefsFileName } from "@/lib/api";
+import * as api from "@/lib/api";
+
+const SETTINGS_KEY = ["settings"] as const;
+
+export function useSettings() {
+	return useQuery({
+		queryKey: SETTINGS_KEY,
+		queryFn: () => api.listSettings(),
+	});
+}
+
+export function useSaveSettings() {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: ({ name, workspaceId }: { name: UserPrefsFileName; workspaceId: string }) =>
+			api.saveSettings(name, workspaceId),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: SETTINGS_KEY });
+		},
+	});
+}

--- a/packages/client/src/lib/api.ts
+++ b/packages/client/src/lib/api.ts
@@ -1,7 +1,10 @@
+import type { UserPrefsBlob, UserPrefsFileName } from "@rockpool/sdk";
 import {
 	gitHubListRepos,
 	gitHubSearchRepos,
 	client as sdkClient,
+	settingsList,
+	settingsSave,
 	workspacesAddPort,
 	workspacesCreate,
 	workspacesList,
@@ -16,6 +19,7 @@ import {
 	GitHubRepoListResponseSchema,
 	GitHubRepoSearchResponseSchema,
 	PortSchema,
+	UserPrefsBlobSchema,
 	WorkspaceListResponseSchema,
 	WorkspaceSchema,
 } from "@rockpool/validators";
@@ -145,11 +149,30 @@ export async function searchGitHubRepos(params: {
 	return GitHubRepoSearchResponseSchema.parse(data) as GitHubRepoSearchResponse;
 }
 
+export async function listSettings(): Promise<UserPrefsBlob[]> {
+	const { data } = await settingsList({ throwOnError: true });
+	return z.array(UserPrefsBlobSchema).parse(data) as UserPrefsBlob[];
+}
+
+export async function saveSettings(
+	name: UserPrefsFileName,
+	workspaceId: string,
+): Promise<UserPrefsBlob> {
+	const { data } = await settingsSave({
+		path: { name },
+		query: { workspaceId },
+		throwOnError: true,
+	});
+	return UserPrefsBlobSchema.parse(data) as UserPrefsBlob;
+}
+
 export type {
 	GitHubRepo,
 	GitHubRepoListResponse,
 	GitHubRepoSearchResponse,
 	Port,
+	UserPrefsBlob,
+	UserPrefsFileName,
 	Workspace,
 	WorkspaceListResponse,
 };

--- a/packages/client/src/routes/workspace-detail.tsx
+++ b/packages/client/src/routes/workspace-detail.tsx
@@ -3,6 +3,7 @@ import { ChevronRight, ExternalLink, Play, Square, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { ConfirmPanel } from "@/components/confirm-panel";
 import { PortsPanel } from "@/components/ports-panel";
+import { PrefsPanel } from "@/components/prefs-panel";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { useNotify } from "@/components/ui/banner";
 import { Button } from "@/components/ui/button";
@@ -200,6 +201,8 @@ export function WorkspaceDetailPage() {
 
 				<PortsPanel workspaceId={workspace.id} workspaceName={workspace.name} />
 			</div>
+
+			{isRunning && <PrefsPanel workspaceId={workspace.id} />}
 		</div>
 	);
 }

--- a/packages/server/src/routes/settings.ts
+++ b/packages/server/src/routes/settings.ts
@@ -83,7 +83,18 @@ export function createSettingsRouter(deps: SettingsRouterDeps): Router {
 				return;
 			}
 
-			const content = await runtime.readFile(workspace.name, workspace.vmIp, filePath);
+			let content: string;
+			try {
+				content = await runtime.readFile(workspace.name, workspace.vmIp, filePath);
+			} catch {
+				res.status(404).json({
+					error: {
+						code: "not_found",
+						message: `File "${filePath}" not found in workspace`,
+					},
+				});
+				return;
+			}
 			const blob = await upsertUserPrefsBlob(db, { name, blob: content });
 			res.json(blob);
 		} catch (err) {


### PR DESCRIPTION
## Summary

- Add **PrefsPanel** component to workspace detail page — table of syncable preference files with "Last saved" timestamps, per-file save buttons, and bulk "Save all"
- Add client API functions (`listSettings`, `saveSettings`) and `useSettings` / `useSaveSettings` hooks
- Handle 404 in settings save route when preference files don't exist on VM yet (code-server only creates them on first user edit)
- Add E2E test suite (`06-preferences-save.spec.ts`) covering API behavior and UI rendering
- Update EDD-020 doc: mark implementation steps complete, update scope exclusions to reflect UI is now shipped

## Test plan

- [ ] `npm run test:e2e:headless` — new E2E tests pass (requires running VM)
- [ ] `npm run test:e2e:ci` — preferences tests skip correctly in CI profile
- [ ] Verify PrefsPanel renders on workspace detail when workspace is running
- [ ] Verify "Save all" gracefully handles files that don't exist yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)