### PR TITLE
Fix srv2 port passthrough from env config

### DIFF
--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -7,6 +7,7 @@ export interface ServerConfig {
 	port: number;
 	srv0Port: number;
 	srv1Port: number;
+	srv2Port: number;
 	dbPath: string;
 	caddyAdminUrl: string;
 	caddyUsername: string;
@@ -46,6 +47,7 @@ export function loadConfig(): ServerConfig {
 		port: Number.parseInt(process.env.PORT ?? "7163", 10),
 		srv0Port: Number.parseInt(process.env.SRV0_PORT ?? "8080", 10),
 		srv1Port: Number.parseInt(process.env.SRV1_PORT ?? "8081", 10),
+		srv2Port: Number.parseInt(process.env.SRV2_PORT ?? "8082", 10),
 		dbPath: resolve(projectRoot, process.env.DB_PATH ?? "rockpool.db"),
 		caddyAdminUrl: process.env.CADDY_ADMIN_URL ?? "http://localhost:2019",
 		caddyUsername: process.env.CADDY_USERNAME ?? "",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -98,6 +98,7 @@ async function bootstrapCaddy(): Promise<void> {
 		controlPlaneUrl,
 		srv0Port: config.srv0Port,
 		srv1Port: config.srv1Port,
+		srv2Port: config.srv2Port,
 	};
 
 	if (config.spaProxyUrl) {

--- a/production.env
+++ b/production.env
@@ -9,6 +9,7 @@ NODE_ENV=development
 PORT=10163
 SRV0_PORT=10080
 SRV1_PORT=10081
+SRV2_PORT=10082
 DB_PATH=rockpool-production.db
 SPA_ROOT=packages/client/dist
 

--- a/test.env
+++ b/test.env
@@ -6,6 +6,7 @@
 PORT=9163
 SRV0_PORT=9080
 SRV1_PORT=9081
+SRV2_PORT=9082
 DB_PATH=/tmp/rockpool-e2e.db
 SPA_ROOT=packages/client/dist
 


### PR DESCRIPTION
## Summary

- `srv2Port` was defined in the Caddy `BootstrapOptions` interface but never wired through `ServerConfig` or passed in `bootstrapCaddy()`, causing all profiles to silently fall back to the hardcoded development port `:8082`
- Add `SRV2_PORT` to `ServerConfig`, pass it through in `bootstrapCaddy()`, and set it in `production.env` (10082) and `test.env` (9082)

## Test plan

- [ ] Restart production profile (`npm run stop:production && npm run start:production`)
- [ ] Verify `curl http://localhost:10019/config/` shows srv2 on `:10082` instead of `:8082`
- [ ] Run `npm run test:e2e:ci` to verify test profile still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)