### PR TITLE
Rootless VM image build (EDD-024)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ $(STAMP_DIR)/rockpool-workspace-container: images/workspace/Dockerfile images/sc
 	touch $@
 
 $(STAMP_DIR)/rockpool-root-vm: images/root-vm/build-root-vm.sh images/root-vm/setup-root-vm.sh images/root-vm/keys/rockpool-root-vm_ed25519.pub | $(STAMP_DIR)
-	sudo images/root-vm/build-root-vm.sh
+	images/root-vm/build-root-vm.sh
 	touch $@
 
 $(STAMP_DIR)/rockpool-root-vm-tart: images/root-vm/build-root-vm-tart.sh images/root-vm/setup-root-vm.sh images/root-vm/keys/rockpool-root-vm_ed25519.pub | $(STAMP_DIR)
@@ -68,7 +68,7 @@ ifeq ($(UNAME_S),Darwin)
 	@echo "  make all"
 else ifeq ($(UNAME_S),Linux)
 	@echo "Detected Linux — install prerequisites:"
-	@echo "  sudo apt install qemu-system-x86 qemu-utils virtiofsd debootstrap grub-pc-bin podman"
+	@echo "  sudo apt install qemu-system-x86 qemu-utils virtiofsd mmdebstrap e2fsprogs podman"
 	@echo "  make all"
 else
 	@echo "Unsupported platform: $(UNAME_S)"

--- a/README.md
+++ b/README.md
@@ -38,10 +38,9 @@ npm start                                     # boots VM, starts stack, tails lo
 ### Linux
 
 ```sh
-sudo apt install qemu-system-x86 qemu-utils virtiofsd debootstrap grub-pc-bin
+sudo apt install qemu-system-x86 qemu-utils virtiofsd mmdebstrap e2fsprogs
 sudo usermod -aG kvm $USER                   # log out and back in
-sudo bash images/root-vm/build-root-vm.sh    # build Root VM image
-sudo chown -R $USER:$USER .qemu/
+images/root-vm/build-root-vm.sh              # build Root VM image (no sudo needed)
 cp development.env.example development.env   # fill in secrets
 npm install
 npm start

--- a/doc/EDD/022_Root_VM.md
+++ b/doc/EDD/022_Root_VM.md
@@ -235,13 +235,13 @@ Debian Bookworm (aarch64 for macOS/Apple Silicon, x86_64 for Linux x86 hosts).
 
 ### Build
 
-Built via `images/root-vm/build-root-vm.sh` using debootstrap + chroot. Produces `.qemu/rockpool-root.qcow2`. The script handles MBR partitioning, GRUB bootloader with serial console, admin user creation, and raw-to-qcow2 conversion.
+Built via `images/root-vm/build-root-vm.sh` using mmdebstrap (rootless, user namespace) + mke2fs -d (no mount) + qemu-img convert. Produces `.qemu/rockpool-root.qcow2`, `.qemu/vmlinuz`, and `.qemu/initrd.img`. The image has no partition table -- the entire disk is a single ext4 filesystem. QEMU boots via direct kernel boot (`-kernel`, `-initrd`, `-append`) instead of GRUB. No sudo required. See [EDD-024](024_Rootless_VM_Image_Build.md).
 
 #### Makefile target
 
 ```makefile
 $(STAMP_DIR)/rockpool-root-vm: images/root-vm/build-root-vm.sh images/root-vm/setup-root-vm.sh images/root-vm/keys/rockpool-root-vm_ed25519.pub
-	sudo bash images/root-vm/build-root-vm.sh
+	images/root-vm/build-root-vm.sh
 	touch $@
 ```
 
@@ -417,12 +417,11 @@ npm start      # boots VM, starts stack, tails logs
 ### Linux (QEMU/KVM)
 
 ```bash
-sudo apt install qemu-system-x86 qemu-utils virtiofsd debootstrap grub-pc-bin
+sudo apt install qemu-system-x86 qemu-utils virtiofsd mmdebstrap e2fsprogs
 sudo usermod -aG kvm $USER   # log out and back in
 
-# Build the Root VM image (requires sudo for debootstrap/chroot)
-sudo bash images/root-vm/build-root-vm.sh
-sudo chown -R $USER:$USER .qemu/
+# Build the Root VM image (no sudo needed)
+images/root-vm/build-root-vm.sh
 
 npm install
 npm start
@@ -461,12 +460,9 @@ Phases 1-2 use the existing stub runtime to validate VM infrastructure. Phases 3
 
 **Steps:**
 
-1. Create a base QEMU VM image (Debian Bookworm x86_64) using debootstrap + chroot (`images/root-vm/build-root-vm.sh`, requires `sudo`)
+1. Create a base QEMU VM image (Debian Bookworm x86_64) using mmdebstrap + mke2fs (`images/root-vm/build-root-vm.sh`, no sudo needed). See [EDD-024](024_Rootless_VM_Image_Build.md).
 2. Write `images/root-vm/setup-root-vm.sh` provisioning script that installs:
-   - Node.js (via fnm)
-   - PM2 (global)
-   - Caddy (from official apt repo)
-   - ElasticMQ (Java + jar at `/opt/elasticmq/`)
+   - Podman (rootless, from Debian repos)
    - SSH server with Rockpool keypair (Ed25519, password auth disabled)
    - Virtiofs fstab entry, systemd-networkd DHCP, serial console
 3. Add Makefile target: `$(STAMP_DIR)/rockpool-root-vm`
@@ -709,9 +705,9 @@ During container state transitions (restart, stop), `podman inspect` may return 
 
 The EDD only mentioned registering Podman in the server's `createRuntimeFromConfig()`. The worker also creates a runtime and needed the same `RUNTIME=podman` branch.
 
-### Image build: debootstrap, not Packer
+### Image build: mmdebstrap, not Packer
 
-The Root VM image is built with `debootstrap` + `chroot` instead of Packer. This avoids a Packer dependency and produces a minimal Debian installation. The build script (`images/root-vm/build-root-vm.sh`) handles partitioning, GRUB installation, and qcow2 conversion.
+The Root VM image is built with `mmdebstrap` (rootless, user namespace) + `mke2fs -d` (no mount) instead of Packer. This avoids a Packer dependency, produces a minimal Debian installation, and requires no sudo. The build script (`images/root-vm/build-root-vm.sh`) produces a raw ext4 image (no partition table), extracts the kernel and initrd for direct kernel boot, and converts to qcow2. See [EDD-024](024_Rootless_VM_Image_Build.md).
 
 ### SSH keypair for Root VM access
 
@@ -774,14 +770,14 @@ When accessing the dashboard via LAN hostname (e.g., `http://homelab:8080/`), Vi
 
 ### 8. `.qemu/` directory ownership
 
-`build-root-vm.sh` runs as root and creates `.qemu/` with root ownership. The start script (running as unprivileged user) can't write PID files. **Workaround:** `sudo chown -R $USER .qemu/` after build. **Image rebuild fix:** ensure the build script's final step chowns the output directory.
+**Resolved by [EDD-024](024_Rootless_VM_Image_Build.md).** The build is now fully rootless -- `.qemu/` is created with the invoking user's ownership. No `sudo chown` workaround needed.
 
 ### Files created
 
 | File | Purpose |
 |------|---------|
-| `images/root-vm/build-root-vm.sh` | Builds QEMU qcow2 image via debootstrap |
-| `images/root-vm/setup-root-vm.sh` | Provisioning script (runs in chroot) |
+| `images/root-vm/build-root-vm.sh` | Builds QEMU qcow2 image via mmdebstrap (rootless) |
+| `images/root-vm/setup-root-vm.sh` | Provisioning script (runs in mmdebstrap hook or tart exec) |
 | `images/root-vm/keys/` | SSH keypair for VM access |
 | `images/workspace/Dockerfile` | Workspace container image |
 | `images/workspace/entrypoint.sh` | code-server entrypoint with optional folder arg |

--- a/images/root-vm/build-root-vm-tart.sh
+++ b/images/root-vm/build-root-vm-tart.sh
@@ -45,7 +45,7 @@ fi
 
 if [ "$(uname -s)" != "Darwin" ]; then
   echo "ERROR: This script is for macOS only."
-  echo "On Linux, use: sudo images/root-vm/build-root-vm.sh"
+  echo "On Linux, use: images/root-vm/build-root-vm.sh"
   exit 1
 fi
 
@@ -75,7 +75,6 @@ fi
 cleanup() {
   echo "Stopping VM..."
   tart stop "$VM_NAME" 2>/dev/null || true
-  rm -f "${ROOT_DIR}/.tart-build-fnm-block.sh"
 }
 
 echo "=== Building Rockpool Root VM (Tart/macOS) ==="
@@ -124,28 +123,6 @@ echo "=== Resizing root partition to fill disk ==="
 tart exec "$VM_NAME" -- sudo bash -c \
   'ROOT_DEV=$(findmnt -n -o SOURCE /) && DISK_DEV=$(lsblk -ndo PKNAME "$ROOT_DEV" | head -1) && growpart "/dev/$DISK_DEV" 1 && resize2fs "$ROOT_DEV"' \
   || echo "WARNING: Partition resize skipped (growpart may not be available)."
-
-echo ""
-echo "=== Installing fnm and Node.js ==="
-tart exec "$VM_NAME" -- bash -c 'curl -fsSL https://fnm.vercel.app/install | bash'
-# shellcheck disable=SC2016
-tart exec "$VM_NAME" -- bash -c \
-  'export PATH="$HOME/.local/share/fnm:$PATH" && eval "$(fnm env)" && fnm install --lts && npm install -g pm2'
-
-echo ""
-echo "=== Configuring fnm PATH for non-interactive sessions ==="
-cat > "${ROOT_DIR}/.tart-build-fnm-block.sh" << 'FNMBLOCK'
-
-# fnm -- must be before interactive guard so SSH commands find node/npm/pm2
-FNM_PATH="$HOME/.local/share/fnm"
-if [ -d "$FNM_PATH" ]; then
-  export PATH="$FNM_PATH:$PATH"
-  eval "$(fnm env)"
-fi
-FNMBLOCK
-tart exec "$VM_NAME" -- bash -c \
-  "cat '${VIRTIOFS_MOUNT}/.tart-build-fnm-block.sh' >> ~/.bashrc"
-rm -f "${ROOT_DIR}/.tart-build-fnm-block.sh"
 
 echo ""
 echo "=== Configuring Virtiofs fstab entry ==="

--- a/images/root-vm/build-root-vm.sh
+++ b/images/root-vm/build-root-vm.sh
@@ -1,32 +1,38 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Build a bootable QEMU qcow2 disk image for the Rockpool Root VM.
-# Requires: debootstrap, qemu-utils, root privileges
+# Build a QEMU qcow2 disk image for the Rockpool Root VM -- fully rootless.
 #
-# Usage: sudo images/root-vm/build-root-vm.sh [output-dir]
+# Uses mmdebstrap (user namespace) + mke2fs -d (no mount) + qemu-img convert.
+# Produces a raw ext4 image (no partition table) and extracts kernel+initrd
+# for QEMU direct kernel boot (no GRUB).
 #
-# Produces: <output-dir>/rockpool-root.qcow2
+# See doc/EDD/024_Rootless_VM_Image_Build.md
+#
+# Usage: images/root-vm/build-root-vm.sh [output-dir]
+#
+# Produces:
+#   <output-dir>/rockpool-root.qcow2   (compressed disk image)
+#   <output-dir>/vmlinuz                (kernel for -kernel flag)
+#   <output-dir>/initrd.img             (initramfs for -initrd flag)
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 OUTPUT_DIR="${1:-${ROOT_DIR}/.qemu}"
 SETUP_SCRIPT="${SCRIPT_DIR}/setup-root-vm.sh"
-SSH_PUBKEY="${SCRIPT_DIR}/keys/rockpool-root-vm_ed25519.pub"
-RAW_IMAGE="${OUTPUT_DIR}/rockpool-root.raw"
+
+TARBALL="${OUTPUT_DIR}/rootfs.tar"
+RAW_IMAGE="${OUTPUT_DIR}/rootfs.raw"
 QCOW2_IMAGE="${OUTPUT_DIR}/rockpool-root.qcow2"
-IMAGE_SIZE_MB=61440
-VM_USER="admin"
+VMLINUZ="${OUTPUT_DIR}/vmlinuz"
+INITRD="${OUTPUT_DIR}/initrd.img"
 
-if [ "$(id -u)" -ne 0 ]; then
-  echo "ERROR: This script must be run as root (sudo)."
-  exit 1
-fi
+IMAGE_SIZE="60G"
 
-for cmd in debootstrap qemu-img grub-install; do
+for cmd in mmdebstrap mke2fs qemu-img fakeroot; do
   if ! command -v "$cmd" &>/dev/null; then
     echo "ERROR: ${cmd} is not installed."
-    echo "Install with: apt install debootstrap qemu-utils grub-pc-bin grub2-common"
+    echo "Install with: sudo apt install mmdebstrap e2fsprogs qemu-utils fakeroot"
     exit 1
   fi
 done
@@ -36,144 +42,76 @@ if [ ! -f "$SETUP_SCRIPT" ]; then
   exit 1
 fi
 
-if [ ! -f "$SSH_PUBKEY" ]; then
-  echo "ERROR: SSH public key not found at $SSH_PUBKEY"
-  echo "Generate it with: ssh-keygen -t ed25519 -f images/root-vm/keys/rockpool-root-vm_ed25519 -N '' -C 'rockpool-root-vm'"
-  exit 1
-fi
-
 mkdir -p "$OUTPUT_DIR"
 
-MOUNT_DIR=$(mktemp -d)
-LOOP_DEV=""
-
+ROOTFS_DIR=""
 cleanup() {
-  echo "Cleaning up..."
-  if mountpoint -q "${MOUNT_DIR}/dev/pts" 2>/dev/null; then umount "${MOUNT_DIR}/dev/pts" || true; fi
-  if mountpoint -q "${MOUNT_DIR}/dev" 2>/dev/null; then umount "${MOUNT_DIR}/dev" || true; fi
-  if mountpoint -q "${MOUNT_DIR}/proc" 2>/dev/null; then umount "${MOUNT_DIR}/proc" || true; fi
-  if mountpoint -q "${MOUNT_DIR}/sys" 2>/dev/null; then umount "${MOUNT_DIR}/sys" || true; fi
-  if mountpoint -q "${MOUNT_DIR}/run" 2>/dev/null; then umount "${MOUNT_DIR}/run" || true; fi
-  if mountpoint -q "${MOUNT_DIR}" 2>/dev/null; then umount "${MOUNT_DIR}" || true; fi
-  if [ -n "$LOOP_DEV" ]; then losetup -d "$LOOP_DEV" 2>/dev/null || true; fi
-  rmdir "$MOUNT_DIR" 2>/dev/null || true
+  rm -f "$TARBALL" "$RAW_IMAGE"
+  [ -n "$ROOTFS_DIR" ] && rm -rf "$ROOTFS_DIR" || true
 }
 trap cleanup EXIT
 
-echo "Creating raw disk image (${IMAGE_SIZE_MB}MB sparse)..."
-dd if=/dev/zero of="$RAW_IMAGE" bs=1M count=0 seek=$IMAGE_SIZE_MB 2>/dev/null
+echo "=== Building Rockpool Root VM (rootless) ==="
+echo ""
 
-echo "Partitioning disk image..."
-parted -s "$RAW_IMAGE" \
-  mklabel msdos \
-  mkpart primary ext4 1MiB 100%
+echo "Installing Debian Bookworm via mmdebstrap (user namespace)..."
+mmdebstrap \
+  --mode=unshare \
+  --variant=important \
+  --include=systemd,systemd-sysv,dbus,linux-image-amd64,apt,ca-certificates \
+  --customize-hook="copy-in $SETUP_SCRIPT /tmp" \
+  --customize-hook='chroot "$1" bash /tmp/setup-root-vm.sh' \
+  --customize-hook='echo "/dev/vda  /  ext4  errors=remount-ro  0 1" > "$1/etc/fstab"' \
+  --customize-hook='echo "rockpool /mnt/rockpool virtiofs defaults,nofail 0 0" >> "$1/etc/fstab"' \
+  --customize-hook='chroot "$1" apt-get clean' \
+  --customize-hook='rm -rf "$1/var/lib/apt/lists"/*' \
+  --customize-hook='rm "$1/tmp/setup-root-vm.sh"' \
+  bookworm "$TARBALL"
 
-LOOP_DEV=$(losetup --find --show --partscan "$RAW_IMAGE")
-PART_DEV="${LOOP_DEV}p1"
+echo ""
+echo "Extracting kernel and initramfs from tarball..."
+KERNEL_PATH=$(tar tf "$TARBALL" | grep -E '^(\./)?boot/vmlinuz-' | head -1)
+INITRD_PATH=$(tar tf "$TARBALL" | grep -E '^(\./)?boot/initrd\.img-' | head -1)
 
-for i in $(seq 1 10); do
-  [ -b "$PART_DEV" ] && break
-  partprobe "$LOOP_DEV" 2>/dev/null || true
-  sleep 0.5
-done
-
-if [ ! -b "$PART_DEV" ]; then
-  echo "ERROR: Partition device ${PART_DEV} not found."
+if [ -z "$KERNEL_PATH" ] || [ -z "$INITRD_PATH" ]; then
+  echo "ERROR: Could not find kernel or initrd in the tarball."
+  echo "  Kernel: ${KERNEL_PATH:-not found}"
+  echo "  Initrd: ${INITRD_PATH:-not found}"
   exit 1
 fi
 
-echo "Formatting partition..."
-mkfs.ext4 -F -q "$PART_DEV"
+tar xf "$TARBALL" -C "$OUTPUT_DIR" "$KERNEL_PATH" "$INITRD_PATH"
+mv "${OUTPUT_DIR}/${KERNEL_PATH}" "$VMLINUZ"
+mv "${OUTPUT_DIR}/${INITRD_PATH}" "$INITRD"
+rm -rf "${OUTPUT_DIR}/boot" "${OUTPUT_DIR}/./boot" 2>/dev/null || true
 
-echo "Mounting partition..."
-mount "$PART_DEV" "$MOUNT_DIR"
-
-echo "Installing Debian Bookworm via debootstrap..."
-debootstrap \
-  --include=systemd,systemd-sysv,dbus,iproute2,openssh-server,sudo,linux-image-amd64,grub-pc,parted \
-  bookworm "$MOUNT_DIR" http://deb.debian.org/debian
-
-echo "Mounting virtual filesystems for chroot..."
-mount --bind /dev "$MOUNT_DIR/dev"
-mount --bind /dev/pts "$MOUNT_DIR/dev/pts"
-mount -t proc proc "$MOUNT_DIR/proc"
-mount -t sysfs sys "$MOUNT_DIR/sys"
-mount -t tmpfs tmpfs "$MOUNT_DIR/run"
-
-echo "Creating admin user..."
-chroot "$MOUNT_DIR" useradd -m -s /bin/bash -G sudo "$VM_USER" 2>/dev/null || true
-chroot "$MOUNT_DIR" sh -c "echo '${VM_USER}:${VM_USER}' | chpasswd"
-
-echo "Running Root VM provisioning script..."
-cp "$SETUP_SCRIPT" "$MOUNT_DIR/tmp/setup-root-vm.sh"
-chroot "$MOUNT_DIR" bash /tmp/setup-root-vm.sh
-rm -f "$MOUNT_DIR/tmp/setup-root-vm.sh"
-
-echo "Installing fnm and Node.js as ${VM_USER}..."
-chroot "$MOUNT_DIR" su - "$VM_USER" -c 'curl -fsSL https://fnm.vercel.app/install | bash'
-# shellcheck disable=SC2016
-chroot "$MOUNT_DIR" su - "$VM_USER" -c \
-  'export PATH="$HOME/.local/share/fnm:$PATH" && eval "$(fnm env)" && fnm install --lts && npm install -g pm2'
-
-echo "Configuring fstab..."
-PART_UUID=$(blkid -s UUID -o value "$PART_DEV")
-cat > "$MOUNT_DIR/etc/fstab" <<EOF
-UUID=${PART_UUID}  /  ext4  errors=remount-ro  0 1
-rockpool /mnt/rockpool virtiofs defaults,nofail 0 0
-EOF
-
-echo "Installing GRUB bootloader..."
-LOOP_BASE=$(basename "$LOOP_DEV")
-mkdir -p "$MOUNT_DIR/boot/grub"
-
-cat > "$MOUNT_DIR/boot/grub/device.map" <<EOF
-(hd0)   ${LOOP_DEV}
-EOF
-
-chroot "$MOUNT_DIR" grub-install --target=i386-pc --boot-directory=/boot "$LOOP_DEV"
-
-cat > "$MOUNT_DIR/etc/default/grub" <<'GRUBCONF'
-GRUB_DEFAULT=0
-GRUB_TIMEOUT=1
-GRUB_CMDLINE_LINUX_DEFAULT=""
-GRUB_CMDLINE_LINUX="console=tty0 console=ttyS0,115200n8"
-GRUB_TERMINAL="serial console"
-GRUB_SERIAL_COMMAND="serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1"
-GRUBCONF
-
-chroot "$MOUNT_DIR" update-grub
-
-rm -f "$MOUNT_DIR/boot/grub/device.map"
-
-echo "Final cleanup inside chroot..."
-chroot "$MOUNT_DIR" apt-get clean
-rm -rf "$MOUNT_DIR/var/lib/apt/lists/"*
-
-echo "Unmounting virtual filesystems..."
-umount "$MOUNT_DIR/dev/pts" || true
-umount "$MOUNT_DIR/dev" || true
-umount "$MOUNT_DIR/proc" || true
-umount "$MOUNT_DIR/sys" || true
-umount "$MOUNT_DIR/run" || true
-
-echo "Unmounting root partition..."
-umount "$MOUNT_DIR"
-
-echo "Converting raw image to qcow2..."
-qemu-img convert -f raw -O qcow2 -c "$RAW_IMAGE" "$QCOW2_IMAGE"
-rm -f "$RAW_IMAGE"
-
-losetup -d "$LOOP_DEV" 2>/dev/null || true
-LOOP_DEV=""
-
-if [ -n "${SUDO_USER:-}" ]; then
-  chown "${SUDO_USER}:${SUDO_USER}" "$QCOW2_IMAGE"
-  chown "${SUDO_USER}:${SUDO_USER}" "$OUTPUT_DIR"
-fi
+echo "  Kernel: ${VMLINUZ}"
+echo "  Initrd: ${INITRD}"
 
 echo ""
-echo "Root VM image built successfully."
-echo "  Image: ${QCOW2_IMAGE}"
-echo "  Size:  $(du -h "$QCOW2_IMAGE" | cut -f1)"
+echo "Creating ext4 disk image (${IMAGE_SIZE}, no mount needed)..."
+# mke2fs -d only accepts directories (not tarballs) on stock Ubuntu/Debian
+# because e2fsprogs is compiled without libarchive. Use fakeroot to extract
+# the tarball with correct ownership faking, then mke2fs -d reads the faked UIDs.
+ROOTFS_DIR=$(mktemp -d)
+export TARBALL ROOTFS_DIR RAW_IMAGE IMAGE_SIZE
+fakeroot bash -c '
+  tar xpf "$TARBALL" -C "$ROOTFS_DIR"
+  mke2fs -t ext4 -d "$ROOTFS_DIR" "$RAW_IMAGE" "$IMAGE_SIZE"
+'
+rm -rf "$ROOTFS_DIR"
+ROOTFS_DIR=""
+
+echo ""
+echo "Converting raw image to compressed qcow2..."
+qemu-img convert -f raw -O qcow2 -c "$RAW_IMAGE" "$QCOW2_IMAGE"
+
+rm -f "$TARBALL" "$RAW_IMAGE"
+
+echo ""
+echo "Root VM image built successfully (no sudo required)."
+echo "  Image:   ${QCOW2_IMAGE} ($(du -h "$QCOW2_IMAGE" | cut -f1))"
+echo "  Kernel:  ${VMLINUZ}"
+echo "  Initrd:  ${INITRD}"
 echo ""
 echo "Start the VM with: npm run start:vm"

--- a/images/root-vm/keys/rockpool-root-vm_ed25519.pub
+++ b/images/root-vm/keys/rockpool-root-vm_ed25519.pub
@@ -1,1 +1,1 @@
-ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA4wik7wMmauHViyfubSKIs3NfgQc5Y4IFZJoSBYlck+ rockpool-root-vm
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOCpmxFuT1c0KTSp4law/4HaqhCa0N9kTu6l/2JuPSdQ rockpool-root-vm

--- a/images/root-vm/setup-root-vm.sh
+++ b/images/root-vm/setup-root-vm.sh
@@ -2,11 +2,15 @@
 set -euo pipefail
 
 # Provision a Debian Bookworm system as a Rockpool Root VM.
-# Runs as root: either inside a chroot (Linux/QEMU build) or via tart exec (macOS/Tart build).
+# Runs as root: inside an mmdebstrap customize-hook (Linux/QEMU) or via tart exec (macOS/Tart).
 # Supports both x86_64 and arm64 (aarch64) architectures.
 # Installs: Podman, SSH server, virtiofs mount support.
 # The control plane (Caddy, ElasticMQ, server, worker, client) runs as Podman Compose
 # containers inside the VM -- no need to install Node.js, Java, or Caddy here.
+#
+# Note: fstab is NOT configured here. Each builder writes its own fstab:
+#   - Linux/QEMU: build-root-vm.sh writes /dev/vda root + virtiofs via mmdebstrap hooks
+#   - macOS/Tart: build-root-vm-tart.sh appends virtiofs entry via tart exec
 
 VM_USER="admin"
 
@@ -51,7 +55,7 @@ SSHCONF
 SSH_DIR="/home/${VM_USER}/.ssh"
 mkdir -p "${SSH_DIR}"
 cat > "${SSH_DIR}/authorized_keys" <<'AUTHKEYS'
-ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA4wik7wMmauHViyfubSKIs3NfgQc5Y4IFZJoSBYlck+ rockpool-root-vm
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOCpmxFuT1c0KTSp4law/4HaqhCa0N9kTu6l/2JuPSdQ rockpool-root-vm
 AUTHKEYS
 chmod 700 "${SSH_DIR}"
 chmod 600 "${SSH_DIR}/authorized_keys"
@@ -61,10 +65,6 @@ systemctl enable ssh 2>/dev/null || ln -sf /lib/systemd/system/ssh.service /etc/
 
 echo "Setting up virtiofs mount point..."
 mkdir -p /mnt/rockpool
-
-if ! grep -q '/mnt/rockpool' /etc/fstab; then
-  echo "rockpool /mnt/rockpool virtiofs defaults,nofail 0 0" >> /etc/fstab
-fi
 
 echo "Setting up persistent state directory..."
 mkdir -p /opt/rockpool

--- a/npm-scripts/start-root-vm.sh
+++ b/npm-scripts/start-root-vm.sh
@@ -185,11 +185,23 @@ start_qemu() {
     exit 1
   fi
 
+  local VMLINUZ="${QEMU_DIR}/vmlinuz"
+  local INITRD="${QEMU_DIR}/initrd.img"
+
   if [ ! -f "$QCOW2_IMAGE" ]; then
     echo "ERROR: Root VM image not found at ${QCOW2_IMAGE}"
     echo ""
     echo "Build it with:"
     echo "  make .stamps/rockpool-root-vm"
+    exit 1
+  fi
+
+  if [ ! -f "$VMLINUZ" ] || [ ! -f "$INITRD" ]; then
+    echo "ERROR: Kernel or initrd not found."
+    echo "  Expected: ${VMLINUZ}"
+    echo "  Expected: ${INITRD}"
+    echo ""
+    echo "Rebuild with: make .stamps/rockpool-root-vm"
     exit 1
   fi
 
@@ -243,6 +255,9 @@ start_qemu() {
     -cpu host \
     -m "$ROOT_VM_MEMORY" \
     -smp "$ROOT_VM_CPUS" \
+    -kernel "$VMLINUZ" \
+    -initrd "$INITRD" \
+    -append "root=/dev/vda rw console=ttyS0,115200n8 rootwait" \
     -drive file="$QCOW2_IMAGE",format=qcow2,if=virtio \
     -object memory-backend-memfd,id=mem,size="$ROOT_VM_MEMORY",share=on \
     -numa node,memdev=mem \


### PR DESCRIPTION
## Summary

- Replace `sudo`-requiring Root VM build with fully rootless pipeline using `mmdebstrap` + `mke2fs -d` + `qemu-img convert`
- Switch from GRUB to QEMU direct kernel boot (`-kernel`, `-initrd`, `-append`) — no partition table needed
- Remove dead fnm/pm2 install blocks from macOS Tart builder
- Fix SSH keypair mismatch (private key didn't match baked public key)

## Changes

| File | What changed |
|------|-------------|
| `images/root-vm/build-root-vm.sh` | Full rewrite: mmdebstrap + fakeroot + mke2fs -d (105 lines, was 180) |
| `npm-scripts/start-root-vm.sh` | Added `-kernel`, `-initrd`, `-append` flags for direct boot |
| `images/root-vm/setup-root-vm.sh` | Updated docs, removed fstab logic (builders handle it) |
| `images/root-vm/build-root-vm-tart.sh` | Removed dead fnm/pm2 install blocks |
| `Makefile` | Dropped `sudo` from root-vm target, updated prerequisites |
| `images/root-vm/keys/*.pub` | Synced with private key |
| `doc/EDD/022_Root_VM.md` | Updated build docs, resolved issue #8 |
| `README.md` | Updated Linux setup instructions |

## Test plan

- [x] `bash images/root-vm/build-root-vm.sh` completes without sudo (342M image)
- [x] `npm run start:vm` boots VM via direct kernel boot (~4s to SSH)
- [x] Virtiofs mount works (`/mnt/rockpool/package.json` exists)
- [x] SSH with project keypair works
- [x] Podman available inside VM
- [ ] `npm run test:e2e:ci` passes (compose on host, no VM needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)