### PR TITLE
Replace curl health check with native fetch, use unique container names

### DIFF
--- a/images/control-plane/Dockerfile
+++ b/images/control-plane/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:22-bookworm-slim
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends podman make python3 g++ curl && \
+    apt-get install -y --no-install-recommends podman make python3 g++ && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/packages/workspace-service/src/health-check.ts
+++ b/packages/workspace-service/src/health-check.ts
@@ -1,5 +1,3 @@
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
 import type { Logger } from "pino";
 
 const HEALTH_POLL_INTERVAL_MS = 1000;
@@ -7,11 +5,9 @@ const HEALTH_POLL_MAX_ATTEMPTS = 60;
 
 export type HealthCheckFn = (vmIp: string) => Promise<void>;
 
-const execFileAsync = promisify(execFile);
-
-function curlHealthCheck(url: string, timeoutSec: number): Promise<boolean> {
-	return execFileAsync("curl", ["-sf", "--max-time", String(timeoutSec), "-o", "/dev/null", url])
-		.then(() => true)
+function fetchHealthCheck(url: string, timeoutMs: number): Promise<boolean> {
+	return fetch(url, { signal: AbortSignal.timeout(timeoutMs) })
+		.then((res) => res.ok)
 		.catch(() => false);
 }
 
@@ -24,7 +20,7 @@ export function defaultHealthCheck(logger: Logger): HealthCheckFn {
 	return async (vmIp: string): Promise<void> => {
 		const url = toHealthUrl(vmIp);
 		for (let attempt = 0; attempt < HEALTH_POLL_MAX_ATTEMPTS; attempt++) {
-			const ok = await curlHealthCheck(url, 5);
+			const ok = await fetchHealthCheck(url, 5000);
 			if (ok) {
 				return;
 			}

--- a/packages/workspace-service/src/workspace-service.ts
+++ b/packages/workspace-service/src/workspace-service.ts
@@ -37,19 +37,23 @@ const VALID_TRANSITIONS: Record<string, WorkspaceStatus[]> = {
 	[WS.error]: [WS.creating],
 };
 
+function containerName(workspace: Workspace): string {
+	return `${workspace.name}-${workspace.id}`;
+}
+
 export function createWorkspaceService(deps: WorkspaceServiceDeps) {
 	const { db, queue, runtime, caddy, logger } = deps;
 	const healthCheck = deps.healthCheck ?? defaultHealthCheck(logger);
 
-	async function configureWorkspace(workspaceName: string, folder?: string): Promise<void> {
+	async function configureWorkspace(workspace: Workspace, folder?: string): Promise<void> {
 		if (runtime.configure) {
 			const env: Record<string, string> = {
-				ROCKPOOL_WORKSPACE_NAME: workspaceName,
+				ROCKPOOL_WORKSPACE_NAME: workspace.name,
 			};
 			if (folder) {
 				env.ROCKPOOL_FOLDER = folder;
 			}
-			await runtime.configure(workspaceName, env);
+			await runtime.configure(containerName(workspace), env);
 		}
 	}
 
@@ -152,16 +156,20 @@ export function createWorkspaceService(deps: WorkspaceServiceDeps) {
 				return;
 			}
 
-			logger.info({ workspaceId: id, name: workspace.name }, "Provisioning workspace");
+			const cname = containerName(workspace);
+			logger.info(
+				{ workspaceId: id, name: workspace.name, containerName: cname },
+				"Provisioning workspace",
+			);
 
-			const vmStatus = await runtime.status(workspace.name);
+			const vmStatus = await runtime.status(cname);
 
 			if (vmStatus === "not_found") {
-				await runtime.create(workspace.name, workspace.image);
-				await runtime.start(workspace.name);
+				await runtime.create(cname, workspace.image);
+				await runtime.start(cname);
 			} else if (vmStatus === "stopped") {
 				logger.info({ workspaceId: id, name: workspace.name }, "VM exists but stopped, starting");
-				await runtime.start(workspace.name);
+				await runtime.start(cname);
 			} else {
 				logger.info(
 					{ workspaceId: id, name: workspace.name },
@@ -173,13 +181,13 @@ export function createWorkspaceService(deps: WorkspaceServiceDeps) {
 			const repoName = repository?.split("/")[1];
 			const folder = repoName ? `/home/admin/${repoName}` : undefined;
 
-			await configureWorkspace(workspace.name, folder);
+			await configureWorkspace(workspace, folder);
 
 			if (repository && runtime.clone) {
-				await runtime.clone(workspace.name, "", repository, opts?.githubAccessToken);
+				await runtime.clone(cname, "", repository, opts?.githubAccessToken);
 			}
 
-			const vmIp = await runtime.getIp(workspace.name);
+			const vmIp = await runtime.getIp(cname);
 			await healthCheck(vmIp);
 
 			if (runtime.writeFile) {
@@ -187,7 +195,7 @@ export function createWorkspaceService(deps: WorkspaceServiceDeps) {
 				await Promise.all(
 					blobs.map((blob) =>
 						runtime
-							.writeFile?.(workspace.name, vmIp, PREFS_FILE_PATHS[blob.name], blob.blob)
+							.writeFile?.(cname, vmIp, PREFS_FILE_PATHS[blob.name], blob.blob)
 							?.catch((err) => {
 								logger.warn(
 									{ workspaceId: id, prefsFile: blob.name, error: err },
@@ -211,13 +219,14 @@ export function createWorkspaceService(deps: WorkspaceServiceDeps) {
 				return;
 			}
 
+			const cname = containerName(workspace);
 			logger.info({ workspaceId: id, name: workspace.name, mode }, "Tearing down workspace");
 
 			if (mode === "stop") {
 				if (workspace.autoSyncPrefs && workspace.vmIp && runtime.readFile) {
 					for (const [name, filePath] of Object.entries(PREFS_FILE_PATHS)) {
 						const content = await runtime
-							.readFile(workspace.name, workspace.vmIp, filePath)
+							.readFile(cname, workspace.vmIp, filePath)
 							.catch(() => null);
 						if (content === null) continue;
 
@@ -234,15 +243,15 @@ export function createWorkspaceService(deps: WorkspaceServiceDeps) {
 				}
 
 				await removeAllPorts(db, id);
-				await runtime.stop(workspace.name);
+				await runtime.stop(cname);
 				await caddy.removeWorkspaceRoute(workspace.name);
 				await updateWorkspaceStatus(db, id, WS.stopped, { vmIp: null });
 				logger.info({ workspaceId: id, name: workspace.name }, "Workspace stopped");
 				return;
 			}
 
-			await runtime.stop(workspace.name).catch(() => {});
-			await runtime.remove(workspace.name).catch(() => {});
+			await runtime.stop(cname).catch(() => {});
+			await runtime.remove(cname).catch(() => {});
 			await caddy.removeWorkspaceRoute(workspace.name);
 			await deleteWorkspace(db, id);
 			logger.info({ workspaceId: id, name: workspace.name }, "Workspace deleted");

--- a/packages/workspace-service/test/workspace-service.test.ts
+++ b/packages/workspace-service/test/workspace-service.test.ts
@@ -90,11 +90,8 @@ describe("provisionAndStart", () => {
 
 		await service.provisionAndStart(ws.id);
 
-		assert.deepEqual(runtime.calls, [
-			"create:prov-create",
-			"start:prov-create",
-			"configure:prov-create",
-		]);
+		const cname = `prov-create-${ws.id}`;
+		assert.deepEqual(runtime.calls, [`create:${cname}`, `start:${cname}`, `configure:${cname}`]);
 		assert.deepEqual(caddy.calls, ["addRoute:prov-create"]);
 
 		const updated = await getWorkspace(db, ws.id);
@@ -118,7 +115,8 @@ describe("provisionAndStart", () => {
 
 		await service.provisionAndStart(ws.id);
 
-		assert.deepEqual(runtime.calls, ["start:prov-start-stopped", "configure:prov-start-stopped"]);
+		const cname = `prov-start-stopped-${ws.id}`;
+		assert.deepEqual(runtime.calls, [`start:${cname}`, `configure:${cname}`]);
 		assert.deepEqual(caddy.calls, ["addRoute:prov-start-stopped"]);
 
 		const updated = await getWorkspace(db, ws.id);
@@ -142,7 +140,7 @@ describe("provisionAndStart", () => {
 
 		await service.provisionAndStart(ws.id);
 
-		assert.deepEqual(runtime.calls, ["configure:prov-running"]);
+		assert.deepEqual(runtime.calls, [`configure:prov-running-${ws.id}`]);
 		assert.deepEqual(caddy.calls, ["addRoute:prov-running"]);
 
 		const updated = await getWorkspace(db, ws.id);
@@ -193,7 +191,7 @@ describe("teardown (stop)", () => {
 
 		await service.teardown(ws.id, "stop");
 
-		assert.deepEqual(runtime.calls, ["stop:tear-stop"]);
+		assert.deepEqual(runtime.calls, [`stop:tear-stop-${ws.id}`]);
 		assert.deepEqual(caddy.calls, ["removeRoute:tear-stop"]);
 
 		const updated = await getWorkspace(db, ws.id);
@@ -267,7 +265,8 @@ describe("teardown (delete)", () => {
 
 		await service.teardown(ws.id, "delete");
 
-		assert.deepEqual(runtime.calls, ["stop:tear-delete", "remove:tear-delete"]);
+		const cname = `tear-delete-${ws.id}`;
+		assert.deepEqual(runtime.calls, [`stop:${cname}`, `remove:${cname}`]);
 		assert.deepEqual(caddy.calls, ["removeRoute:tear-delete"]);
 
 		const deleted = await getWorkspace(db, ws.id);
@@ -293,7 +292,7 @@ describe("teardown (delete)", () => {
 
 		await service.teardown(ws.id, "delete");
 
-		assert.deepEqual(runtime.calls, ["remove:tear-delete-err"]);
+		assert.deepEqual(runtime.calls, [`remove:tear-delete-err-${ws.id}`]);
 		assert.deepEqual(caddy.calls, ["removeRoute:tear-delete-err"]);
 
 		const deleted = await getWorkspace(db, ws.id);
@@ -319,7 +318,7 @@ describe("teardown (delete)", () => {
 
 		await service.teardown(ws.id, "delete");
 
-		assert.deepEqual(runtime.calls, ["stop:tear-delete-rm-err"]);
+		assert.deepEqual(runtime.calls, [`stop:tear-delete-rm-err-${ws.id}`]);
 		assert.deepEqual(caddy.calls, ["removeRoute:tear-delete-rm-err"]);
 
 		const deleted = await getWorkspace(db, ws.id);
@@ -372,8 +371,9 @@ describe("provisionAndStart with clone", () => {
 			githubAccessToken: "ghp_test123",
 		});
 
-		assert.ok(runtime.calls.includes("clone:prov-clone:octocat/Hello-World"));
-		assert.ok(runtime.calls.includes("configure:prov-clone"));
+		const cname = `prov-clone-${ws.id}`;
+		assert.ok(runtime.calls.includes(`clone:${cname}:octocat/Hello-World`));
+		assert.ok(runtime.calls.includes(`configure:${cname}`));
 		assert.deepEqual(caddy.calls, ["addRoute:prov-clone"]);
 
 		const updated = await getWorkspace(db, ws.id);
@@ -398,7 +398,7 @@ describe("provisionAndStart with clone", () => {
 
 		const cloneCalls = runtime.calls.filter((c) => c.startsWith("clone:"));
 		assert.equal(cloneCalls.length, 0);
-		assert.ok(runtime.calls.includes("configure:prov-no-clone"));
+		assert.ok(runtime.calls.includes(`configure:prov-no-clone-${ws.id}`));
 	});
 
 	it("clone failure puts workspace in error state via thrown error", async () => {


### PR DESCRIPTION
## Summary

- **Health check**: Replace `execFile("curl")` with native `fetch()` + `AbortSignal.timeout()`, dropping the `curl` dependency from the control-plane Dockerfile
- **Container naming**: Derive container names as `${name}-${id}` instead of using the user-supplied workspace name directly. The ID suffix guarantees uniqueness at the podman level, preventing stale volume collisions (postmortem bug 5). Caddy routes continue to use the human-readable workspace name for URL paths.

## Test plan

- [x] All 16 workspace-service unit tests pass
- [ ] `npm run test:e2e:headless` passes (container naming change is end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)